### PR TITLE
Use EXIFTool Available to also Generate ImagePreviews

### DIFF
--- a/FrmMainApp.cs
+++ b/FrmMainApp.cs
@@ -1605,23 +1605,28 @@ public partial class FrmMainApp : Form
             // it's easier to call the create-preview here than in the other one because focusedItems misbehave/I don't quite understand it/them
             if (lvw_FileList.SelectedItems.Count > 0)
             {
-                string fileNameWithPath = Path.Combine(FolderName +
-                                                       lvw_FileList.SelectedItems[index: 0]
-                                                           .Text);
+                string fileNameWithPath = Path.Combine(
+                    FolderName + lvw_FileList.SelectedItems[index: 0].Text);
 
                 if (File.Exists(path: fileNameWithPath))
                 {
-                    await HelperStatic.GenericCreateImagePreview(
-                        fileNameWithPath: fileNameWithPath, initiator: "FrmMainApp");
+                    // Todo localized error message in return string
+                    Task<(Image, string)> tImg = HelperStatic.GetImage(fileNameWithPath, _ExifTool, true);
+                    tImg.Wait();
+                    if (tImg.IsCompleted)
+                    {
+                        (Image img, string res) = tImg.Result;
+                        if (img != null)
+                            pbx_imagePreview.Image = img;
+                        else
+                            pbx_imagePreview.SetErrorMessage(res);
+                    }
                 }
-                else
-                {
+                else  // No File ...
                     pbx_imagePreview.Image = null;
-                }
             }
 
             NavigateMapGo();
-            // pbx_imagePreview.Image = null;
         }
     }
 


### PR DESCRIPTION
Hi @nemethviktor ,

I created a first version.

Open topics / Questions.
* Preview logic now is to per default to use a preview (instead of as previously the full image).
  **--> do we want it this way or should normally the full image (when storing in DEs more memory needed) be used?**
* No separate exifToll used yet
* Error message not finalized yet (exception details should go to log, localized error be shown)
* No storing / caching in DEs, yet
* No locking mechanism yet (to protect against concurrent write operation)
  **--> is there one with the previous preview generation code?**
* Only for the main list view, editform and apicallthing are not changed, yet