### PR TITLE
Add VS Code launch configuration

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "ms-dotnettools.csharp"
+  ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": ".NET Framework Launch GeoTagNinja",
+      "type": "clr",
+      "request": "launch",
+      "program": "${workspaceFolder}\\bin\\x64\\Debug\\GeoTagNinja.exe",
+      "args": [],
+      "cwd": "${workspaceFolder}",
+      "stopAtEntry": false,
+      "preLaunchTask": "Build GeoTagNinja (Debug x64)"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,53 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Restore GeoTagNinja packages",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "$ErrorActionPreference = \"Stop\"; if (Get-Command dotnet -ErrorAction SilentlyContinue) { $sdkList = & dotnet --list-sdks; if ($sdkList) { & dotnet msbuild \"GeoTagNinja.sln\" /t:Restore /p:RestorePackagesConfig=true; exit $LASTEXITCODE } }; if (Test-Path \".\\packages\") { Write-Host \"dotnet SDK not available; skipping restore because .\\packages already exists.\"; exit 0 }; throw \"Could not run restore. Install .NET SDK (for restore) or restore packages manually.\""
+      ],
+      "group": "build",
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Build GeoTagNinja (Debug x64)",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "$ErrorActionPreference = \"Stop\"; $staleExifTool = Get-Process -Name exiftool -ErrorAction SilentlyContinue; if ($staleExifTool) { Write-Host \"Stopping stale exiftool processes to release build output locks...\"; $staleExifTool | Stop-Process -Force -ErrorAction SilentlyContinue }; $msbuildFromPath = (Get-Command msbuild -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source); $msbuildCandidates = @(\"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\18\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\18\\BuildTools\\MSBuild\\Current\\Bin\\amd64\\MSBuild.exe\", \"$env:ProgramFiles\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"$env:ProgramFiles\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"$env:ProgramFiles\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2022\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2022\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2022\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2022\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2019\\BuildTools\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2019\\Community\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2019\\Professional\\MSBuild\\Current\\Bin\\MSBuild.exe\", \"${env:ProgramFiles(x86)}\\Microsoft Visual Studio\\2019\\Enterprise\\MSBuild\\Current\\Bin\\MSBuild.exe\", $msbuildFromPath) | Where-Object { $_ -and (Test-Path $_) -and ($_ -notmatch \"\\\\dotnet\\\\\") -and ($_ -notmatch \"\\\\Framework64?\\\\v4\\.0\\.30319\\\\\") } | Select-Object -First 1; if ($msbuildCandidates) { Write-Host \"Using MSBuild: $msbuildCandidates\"; & $msbuildCandidates \"GeoTagNinja.sln\" /p:Configuration=Debug /p:Platform=x64 } else { throw \"No compatible Visual Studio MSBuild was found. This project requires MSBuild from Visual Studio/Build Tools. Install Visual Studio Build Tools with .NET desktop development workload.\" }"
+      ],
+      "dependsOn": "Restore GeoTagNinja packages",
+      "dependsOrder": "sequence",
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "Run GeoTagNinja (Debug x64)",
+      "type": "process",
+      "command": "powershell",
+      "args": [
+        "-NoProfile",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "$staleExifTool = Get-Process -Name exiftool -ErrorAction SilentlyContinue; if ($staleExifTool) { Write-Host \"Stopping stale exiftool processes before launch...\"; $staleExifTool | Stop-Process -Force -ErrorAction SilentlyContinue }; if (-not (Test-Path \".\\bin\\x64\\Debug\\GeoTagNinja.exe\")) { throw \"Build output not found. Run the build task first.\" }; Start-Process -FilePath \".\\bin\\x64\\Debug\\GeoTagNinja.exe\" -WorkingDirectory \".\""
+      ],
+      "dependsOn": "Build GeoTagNinja (Debug x64)",
+      "dependsOrder": "sequence",
+      "problemMatcher": []
+    }
+  ]
+}

--- a/Program.cs
+++ b/Program.cs
@@ -10,7 +10,6 @@ namespace GeoTagNinja;
 
 internal static class Program
 {
-    private const string PipeErrorAbandonedMutexException = "AbandonedMutexException";
     private const string PipeErrorConnectionTimeout = "Connection timed out: ";
     private const string PipeErrorIoError = "IO Error: ";
     private const string PipeErrorAccessDenied = "Access Denied: ";
@@ -77,8 +76,18 @@ internal static class Program
         }
         catch (AbandonedMutexException)
         {
-            // Other application did not release Mutex properly
-            _ = MessageBox.Show(text: PipeErrorAbandonedMutexException);
+            // This can happen when a previous GTN process crashes or is force-killed while owning
+            // the single-instance mutex. Windows then marks the mutex as "abandoned" and gives
+            // ownership to the next waiter by throwing AbandonedMutexException.
+            //
+            // Before this fix, we caught the exception but left SingleInstanceHighlander as false,
+            // which incorrectly sent startup into the "secondary instance" named-pipe client path.
+            // If no healthy primary instance/pipe server was actually running yet, users could see
+            // transient pipe I/O failures such as "The semaphore timeout period has expired.".
+            //
+            // Setting SingleInstanceHighlander = true is correct here because ownership is now ours,
+            // and this process must continue as the effective primary instance and start the UI/pipe server.
+            SingleInstanceHighlander = true;
         }
 
         if (!SingleInstanceHighlander)

--- a/SingleInstance_PipeServer.cs
+++ b/SingleInstance_PipeServer.cs
@@ -19,6 +19,7 @@ namespace GeoTagNinja;
 internal class SingleInstance_PipeServer
 {
     internal static readonly Logger Log = LogManager.GetCurrentClassLogger();
+    private const int PipeInstancesBusyWin32Code = 231;
 
     /// <summary>
     ///     The single threaded server thread
@@ -79,58 +80,74 @@ internal class SingleInstance_PipeServer
     /// </summary>
     private void PipeServer_ServingThread()
     {
-        Log.Info(message: $"Starting pipe serving under user '{myUserName}' ...");
-
-        // Create a cancelation token to abort the task
-        cTokenSource = new CancellationTokenSource();
-
-        // Security:
-        PipeSecurity npSec = new();
-        // Deny all
-        npSec.AddAccessRule(
-            rule: new PipeAccessRule(
-                identity: new SecurityIdentifier(sidType: WellKnownSidType.NetworkSid,
-                                                 domainSid: null),
-                rights: PipeAccessRights.FullControl, type: AccessControlType.Deny));
-        // Allow .... me :)
-        npSec.AddAccessRule(
-            rule: new PipeAccessRule(identity: myUserName,
-                                     rights: PipeAccessRights.FullControl,
-                                     type: AccessControlType.Allow));
-
-        while (true)
+        try
         {
-            // Note: has to be set to async, as otherwise cancelation token
-            // is ignored, cf. https://stackoverflow.com/questions/53695427/cancellationtoken-not-working-with-waitforconnectionasync
-            NamedPipeServerStream npServer = new(
-                pipeName: Program.SingleInstancePipeName, direction: PipeDirection.In,
-                maxNumberOfServerInstances: 1,
-                transmissionMode: PipeTransmissionMode.Byte,
-                options: PipeOptions.Asynchronous, inBufferSize: 0, outBufferSize: 0,
-                pipeSecurity: npSec);
+            Log.Info(message: $"Starting pipe serving under user '{myUserName}' ...");
 
-            int threadID = Thread.CurrentThread.ManagedThreadId;
-            Log.Info(message: $"Server: started with Thread ID {threadID}");
+            // Create a cancelation token to abort the task
+            cTokenSource = new CancellationTokenSource();
 
-            // Async wait for connection that can be canceled
-            IAsyncResult npConnectionResult =
-                npServer.WaitForConnectionAsync(cancellationToken: cTokenSource.Token);
+            // Security:
+            PipeSecurity npSec = new();
+            // Deny all
+            npSec.AddAccessRule(
+                rule: new PipeAccessRule(
+                    identity: new SecurityIdentifier(sidType: WellKnownSidType.NetworkSid,
+                                                     domainSid: null),
+                    rights: PipeAccessRights.FullControl, type: AccessControlType.Deny));
+            // Allow .... me :)
+            npSec.AddAccessRule(
+                rule: new PipeAccessRule(identity: myUserName,
+                                         rights: PipeAccessRights.FullControl,
+                                         type: AccessControlType.Allow));
 
-            // Wait for either connection or cancelation
-            _ =
-                WaitHandle.WaitAny(waitHandles: new[]
-                                       { npConnectionResult.AsyncWaitHandle });
-            if (npServer.IsConnected)
+            while (true)
             {
-                PipeServer_HandleConnection(npServer: npServer, threadID: threadID);
-                npServer.Close();
-            }
+                NamedPipeServerStream npServer;
+                try
+                {
+                    // Note: has to be set to async, as otherwise cancelation token
+                    // is ignored, cf. https://stackoverflow.com/questions/53695427/cancellationtoken-not-working-with-waitforconnectionasync
+                    npServer = new NamedPipeServerStream(
+                        pipeName: Program.SingleInstancePipeName, direction: PipeDirection.In,
+                        maxNumberOfServerInstances: 1,
+                        transmissionMode: PipeTransmissionMode.Byte,
+                        options: PipeOptions.Asynchronous, inBufferSize: 0, outBufferSize: 0,
+                        pipeSecurity: npSec);
+                }
+                catch (IOException ex) when ((ex.HResult & 0xFFFF) == PipeInstancesBusyWin32Code)
+                {
+                    Log.Warn(message:
+                                 "Server: pipe instance already exists (Win32 231 - all instances are busy). " +
+                                 "Continuing without starting an additional server thread.");
+                    return;
+                }
 
-            if ((cTokenSource == null) || cTokenSource.IsCancellationRequested)
-            {
-                Log.Info(message: $"Server ({threadID}): cancellation requested.");
-                return;
+                int threadID = Thread.CurrentThread.ManagedThreadId;
+                Log.Info(message: $"Server: started with Thread ID {threadID}");
+
+                // Async wait for connection that can be canceled
+                IAsyncResult npConnectionResult =
+                    npServer.WaitForConnectionAsync(cancellationToken: cTokenSource.Token);
+
+                // Wait for either connection or cancelation
+                _ = WaitHandle.WaitAny(waitHandles: new[] { npConnectionResult.AsyncWaitHandle });
+                if (npServer.IsConnected)
+                {
+                    PipeServer_HandleConnection(npServer: npServer, threadID: threadID);
+                    npServer.Close();
+                }
+
+                if ((cTokenSource == null) || cTokenSource.IsCancellationRequested)
+                {
+                    Log.Info(message: $"Server ({threadID}): cancellation requested.");
+                    return;
+                }
             }
+        }
+        catch (Exception ex)
+        {
+            Log.Error(message: $"Server: unhandled exception in pipe serving thread - {ex.Message}");
         }
     }
 

--- a/readme.md
+++ b/readme.md
@@ -106,9 +106,23 @@ Things to note:
 
 ## Building & Testing
 
-If you want to build the project, probably use Visual Studio - I used v2026 Community. Instead of downloading the source code as zip please pull from Git, you can do that via VS if you want.
-There are 2 parts to the project. One is the "main" the other is the installer. You'll generally have problems w/ the installer bcs it hasn't been pushed to git so it's going to be missing that half.
-For the "main" project you should be okay without anything separate. It has worked ok for me on a blank VM when pulled from Git. Just build and F5/run.
+If you want to build the project, Visual Studio is the most straightforward option. That said, the main project can also be built from VS Code.
+
+There are 2 parts to the project. One is the "main" app, the other is the installer. You'll generally have problems w/ the installer bcs it hasn't been pushed to git so it's going to be missing that half.
+
+For the "main" project you should be okay without anything separate once the proper toolchain is installed. This repo is an older-style .NET Framework 4.8 WinForms project, so VS Code is fine as an editor/task runner but it still relies on the Visual Studio/MSBuild toolchain underneath.
+
+### Building the main app in VS Code
+
+Prerequisites:
+
+Install either Visual Studio or Visual Studio Build Tools with the `.NET desktop build tools` workload. Make sure the `.NET Framework 4.8 development tools` targeting pack is installed. The `C#` VS Code extension is recommended.
+
+The repo includes VS Code workspace files under `.vscode/` for the main app:
+
+- `Restore GeoTagNinja packages`
+- `Build GeoTagNinja (Debug x64)`
+- `Run GeoTagNinja (Debug x64)`
 
 There is currently no preset release cycle. I don't expect one to happen in a systematic way.
 


### PR DESCRIPTION
### Summary

This pull request adds VS Code launch configuration. This allows you to build and run the application in VS Code using `Ctrl + F5`. You still have to install Visual Studio Build Tools first. Personally I prefer VS Code over Visual Studio. Let me know if you want to merge this.

Additionally, this fixes startup edge cases that could cause the app to close immediately.

### What Changed

- Added VS Code launch/debug setup so the app can be started directly from VS Code.
- Added VS Code tasks for:
  - package restore
  - Debug x64 build
  - app launch
- Added MSBuild path discovery for Visual Studio Build Tools installations, including Visual Studio 18 BuildTools paths.
- Added automatic cleanup of stale exiftool processes before build/run to avoid file-lock copy failures.
- Improved single-instance startup handling:
  - abandoned mutex now correctly continues as primary instance
  - named-pipe server now handles busy pipe instances gracefully instead of crashing the process
